### PR TITLE
Result output [0,60] corrected

### DIFF
--- a/fuzzify.py
+++ b/fuzzify.py
@@ -23,15 +23,15 @@ class washing_machine:
     wash_time['VeryLong'] = fuzz.trimf(wash_time.universe, [40, 60, 60])
 
     # Rule Application
-    rule1 = ctrl.Rule(degree_dirt['High'] | type_dirt['Fat'], wash_time['VeryLong'])
-    rule2 = ctrl.Rule(degree_dirt['Medium'] | type_dirt['Fat'], wash_time['long'])
-    rule3 = ctrl.Rule(degree_dirt['Low'] | type_dirt['Fat'], wash_time['long'])
-    rule4 = ctrl.Rule(degree_dirt['High'] | type_dirt['Medium'], wash_time['long'])
-    rule5 = ctrl.Rule(degree_dirt['Medium'] | type_dirt['Medium'], wash_time['medium'])
-    rule6 = ctrl.Rule(degree_dirt['Low'] | type_dirt['Medium'], wash_time['medium'])
-    rule7 = ctrl.Rule(degree_dirt['High'] | type_dirt['NonFat'], wash_time['medium'])
-    rule8 = ctrl.Rule(degree_dirt['Medium'] | type_dirt['NonFat'], wash_time['short'])
-    rule9 = ctrl.Rule(degree_dirt['Low'] | type_dirt['NonFat'], wash_time['very_short'])
+    rule1 = ctrl.Rule(degree_dirt['High'] & type_dirt['Fat'], wash_time['VeryLong'])
+    rule2 = ctrl.Rule(degree_dirt['Medium'] & type_dirt['Fat'], wash_time['long'])
+    rule3 = ctrl.Rule(degree_dirt['Low'] & type_dirt['Fat'], wash_time['long'])
+    rule4 = ctrl.Rule(degree_dirt['High'] & type_dirt['Medium'], wash_time['long'])
+    rule5 = ctrl.Rule(degree_dirt['Medium'] & type_dirt['Medium'], wash_time['medium'])
+    rule6 = ctrl.Rule(degree_dirt['Low'] & type_dirt['Medium'], wash_time['medium'])
+    rule7 = ctrl.Rule(degree_dirt['High'] & type_dirt['NonFat'], wash_time['medium'])
+    rule8 = ctrl.Rule(degree_dirt['Medium'] & type_dirt['NonFat'], wash_time['short'])
+    rule9 = ctrl.Rule(degree_dirt['Low'] & type_dirt['NonFat'], wash_time['very_short'])
 
     # Washing Control Simulation
     washing_ctrl = ctrl.ControlSystem([rule1, rule2, rule3, rule4, rule5, rule6, rule7, rule8, rule9])

--- a/fuzzify.py
+++ b/fuzzify.py
@@ -6,7 +6,7 @@ class washing_machine:
 
     degree_dirt = ctrl.Antecedent(np.arange(0, 101, 1), 'degree_dirt')
     type_dirt = ctrl.Antecedent(np.arange(0, 101, 1), 'type_dirt')
-    wash_time = ctrl.Consequent(np.arange(0, 61, 1), 'wash_time')
+    wash_time = ctrl.Consequent(np.arange(0, 61, 1), 'wash_time', 'som')
 
     degree_names = ['Low', 'Medium', 'High']
     type_names = ['NonFat', 'Medium', 'Fat']


### PR DESCRIPTION
@Khyat  
Result output was not correct
For, `dirt type : 100` and `dirt percentage : 100`, it would not output `60` minutes.

The changes will solve this [issue](https://github.com/Khyat/fuzzy_logic-washing_machine/issues/1)
## **_Changes made :_**

Change `|` to `&` in rules in [fuzzify.py](https://github.com/Khyat/fuzzy_logic-washing_machine/blob/master/fuzzify.py) at line no. 26 to 34

<img width="538" alt="image" src="https://user-images.githubusercontent.com/76490924/188310321-91b994a5-3308-44dc-aedb-a8d4fb2768c2.png">

This will give output 

<img width="517" alt="image" src="https://user-images.githubusercontent.com/76490924/188310144-71c99361-81c2-496c-8368-424ae15d79fb.png">

Next, add defuzzification technique `'mom'` or `'som'` in consequent declaration at line no. 9 in [fuzzify.py](https://github.com/Khyat/fuzzy_logic-washing_machine/blob/master/fuzzify.py)
* `'centroid'` : Centroid of area
* `'bisector'` : bisector of area
* `'mom'`     : mean of maximum
* `'som'`       : min of maximum
* `'lom'`       : max of maximum

<img width="467" alt="image" src="https://user-images.githubusercontent.com/76490924/188324864-de45aa3f-abef-434b-ba53-b142c4d45ebe.png">

This will give the correct output

<img width="491" alt="image" src="https://user-images.githubusercontent.com/76490924/188325021-b3924c80-4462-448f-bdb4-a55bf07d37de.png">